### PR TITLE
Only poll for direct flights 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Feel free to spend as much or as little time as you'd like, as long as the follo
 
 ## Task
 
-- Use our 'live pricing' API to find **return flights from Edinburgh to London, departing next Monday and returning the following day**.
+- Use our 'live pricing' API to find **direct return flights from Edinburgh to London, departing next Monday and returning the following day**.
 
 - We've provided a basic API client in Node.js - see the API section below. You can build this out, copy from it, or roll your own.
 

--- a/server/src/live-pricing.js
+++ b/server/src/live-pricing.js
@@ -8,6 +8,7 @@ const config = require('./config');
 
 const PRICING_URL = `${config.skyscannerApi}apiservices/pricing/v1.0`;
 const POLL_DELAY = 1000;
+const STOPS = 0;
 const STATUS_CODES = {
   CREATED: 201,
   NOT_MODIFIED: 304,
@@ -53,7 +54,7 @@ const poll = async (location) => {
   await throttle();
   console.log('Polling results..');
   try {
-    const response = await fetch(`${location}?apikey=${config.apiKey}`);
+    const response = await fetch(`${location}?apikey=${config.apiKey}&stops=${STOPS}`);
     if (response.status === STATUS_CODES.NOT_MODIFIED) {
       return cache;
     }


### PR DESCRIPTION
Sets the query parameter stops to 0 to only poll for direct flights, as documented here

https://skyscanner.github.io/slate/?_ga=1.104705984.172843296.1446781555#polling-the-results